### PR TITLE
pass context to button constructor

### DIFF
--- a/src/js/bs3/module/Buttons.js
+++ b/src/js/bs3/module/Buttons.js
@@ -570,7 +570,7 @@ define([
         for (var idx = 0, len = buttons.length; idx < len; idx++) {
           var button = context.memo('button.' + buttons[idx]);
           if (button) {
-            $group.append(typeof button === 'function' ? button() : button);
+            $group.append(typeof button === 'function' ? button(context) : button);
           }
         }
         $group.appendTo($container);


### PR DESCRIPTION
The docs for adding custom buttons (http://summernote.org/deep-dive/#custom-button) show the constructor getting passed the context, but it wasn't, so I added the argument.
